### PR TITLE
[warning] format ‘%d’ expects argument of type ‘int’, but argument 2 …

### DIFF
--- a/SOURCE/diagnose-tools/kprobe.cc
+++ b/SOURCE/diagnose-tools/kprobe.cc
@@ -163,7 +163,7 @@ static void do_settings(const char *arg)
 		printf("    进程名称：%s\n", settings.comm);
 		printf("    函数名称：%s\n", settings.func);
 		printf("    CPUS：%s\n", settings.cpus);
-		printf("    RAW-STACK：%d\n", settings.raw_stack);
+		printf("    RAW-STACK：%lu\n", settings.raw_stack);
 		printf("    输出级别：%d\n", settings.verbose);
 	} else {
 		printf("获取kprobe设置失败，请确保正确安装了diagnose-tools工具\n");


### PR DESCRIPTION
for printf format.