### PR TITLE
解决 make tools '/usr/bin/ld: cannot find -llzma' 对libxml2的依赖

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ devel:
 	yum install -y elfutils-libelf-devel
 	yum install -y java-1.7.0-openjdk-devel.x86_64
 	yum install -y rpm-build
+	yum install -y libxml2-devel
 	sh ./vender/devel.sh
 
 deps:


### PR DESCRIPTION
解决 make tools '/usr/bin/ld: cannot find -llzma' 对libxml2的依赖