### PR TITLE
 解决 insmod diagnose.ko ERROR

### DIFF
--- a/SOURCE/module/kernel/mutex.c
+++ b/SOURCE/module/kernel/mutex.c
@@ -568,6 +568,8 @@ static int lookup_syms(void)
 	if (orig___mutex_unlock_slowpath == NULL)
 		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.18");
 	if (orig___mutex_unlock_slowpath == NULL)
+		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.17");
+	if (orig___mutex_unlock_slowpath == NULL)
 		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath");
 	if (orig___mutex_unlock_slowpath == NULL)
 		return -EINVAL;


### PR DESCRIPTION
insmod: ERROR: could not insert module /usr/diagnose-tools/lib/5.3.0-51-generic//diagnose.ko: Invalid parameters