### PR TITLE
在ubuntu 20.04系统中，默认使用gcc 9.3.0版本进行编译。

### DIFF
--- a/SOURCE/diagnose-tools/jmaps.cc
+++ b/SOURCE/diagnose-tools/jmaps.cc
@@ -314,10 +314,11 @@ int open_file(int pid, const char *subdir)
 void touch_file(const char *fn)
 {
     int fd;
+    ssize_t __attribute__ ((unused)) size;
 
     fd = open(fn, O_WRONLY|O_CREAT, 0666);
     if (fd >= 0) {
-        write(fd, "\n", 1);
+        size = write(fd, "\n", 1);
         close(fd);
     } else {
         CHECK_PRINT(fd, "touch_file: %s\n", fn);
@@ -583,6 +584,7 @@ std::string read_file(const char *fn)
     int fd;
     struct stat st;
     std::string ret;
+    ssize_t __attribute__ ((unused)) size;
 
     fd = open(fn, 0);
     if (fd < 0)
@@ -590,7 +592,7 @@ std::string read_file(const char *fn)
 
     fstat(fd, &st);
     ret.resize(st.st_size);
-    read(fd, (char *)ret.data(), st.st_size);
+    size = read(fd, (char *)ret.data(), st.st_size);
     close(fd);
 
     return ret;

--- a/SOURCE/diagnose-tools/main.cc
+++ b/SOURCE/diagnose-tools/main.cc
@@ -106,17 +106,17 @@ static int usage(int argc, char **argv)
 
 static int do_install(int argc, char **argv)
 {
-	system("\\cp -f /usr/diagnose-tools/libperfmap.so /tmp");
-	system("/usr/diagnose-tools/diagnose-tools.sh install");
+	int ret;
 
-	return 0;
+	ret = system("\\cp -f /usr/diagnose-tools/libperfmap.so /tmp");
+	ret = system("/usr/diagnose-tools/diagnose-tools.sh install");
+
+	return ret;
 }
 
 static int do_uninstall(int argc, char **argv)
 {
-	system("/usr/diagnose-tools/diagnose-tools.sh uninstall");
-
-	return 0;
+	return	system("/usr/diagnose-tools/diagnose-tools.sh uninstall");
 }
 
 int do_flame(int argc, char *argv[])
@@ -130,6 +130,7 @@ int do_flame(int argc, char *argv[])
 	char *input = NULL;
 	char *output = NULL;
 	char cmd[1024];
+	int __attribute__ ((unused)) ret;
 
 	while (1) {
 		int option_index = -1;
@@ -160,7 +161,7 @@ int do_flame(int argc, char *argv[])
 	sprintf(cmd, "cat %s | awk \'{if (substr($1,1,1) == \"#\") {print substr($0, 3)}}\' " \
 		"| c++filt | /usr/diagnose-tools/flame-graph/stackcollapse.pl " \
 		"| /usr/diagnose-tools/flame-graph/flamegraph.pl > %s", input, output);
-	system(cmd);
+	ret = system(cmd);
 
 	return 0;
 }

--- a/SOURCE/diagnose-tools/misc.cc
+++ b/SOURCE/diagnose-tools/misc.cc
@@ -372,7 +372,7 @@ void write_syslog(int enabled, const char mod[], struct timeval *tv, unsigned lo
 
 	str_log.append(ss.str());
 	str_log.append(root.toStyledString());
-	syslog(LOG_DEBUG,str_log.c_str());
+	syslog(LOG_DEBUG, "%s", str_log.c_str());
 
 	return;
 }

--- a/SOURCE/diagnose-tools/perf.cc
+++ b/SOURCE/diagnose-tools/perf.cc
@@ -350,7 +350,7 @@ static void write_log(const char *src_file, char *dest_file)
 
 		if (1 == syslog_enabled)
 		{
-			syslog(LOG_DEBUG, tp.c_str());
+			syslog(LOG_DEBUG, "%s", tp.c_str());
 		}
 	}
 
@@ -392,10 +392,10 @@ static void do_sls(char *arg)
 
 			extract_variant_buffer(variant_buf, len, sls_extract, NULL);
 
-			system("python /usr/diagnose-tools/flame-graph/encode.py /tmp/perf.txt | /usr/diagnose-tools/flame-graph/stackcollapse.pl > /tmp/flame.txt");
+			ret = system("python /usr/diagnose-tools/flame-graph/encode.py /tmp/perf.txt | /usr/diagnose-tools/flame-graph/stackcollapse.pl > /tmp/flame.txt");
 
 			buf.append("python /usr/diagnose-tools/flame-graph/decode.py /tmp/flame.txt > /tmp/perf_stripped.txt");
-			system(buf.c_str());
+			ret = system(buf.c_str());
 
 			write_log("/tmp/perf_stripped.txt", store_file);
 			system("echo \"\"> /tmp/perf.txt");

--- a/SOURCE/diagnose-tools/run_trace.cc
+++ b/SOURCE/diagnose-tools/run_trace.cc
@@ -948,7 +948,7 @@ __attribute__((unused)) static void sls_test(void)
 {
 	int i;
 	struct timeval delay;
-	int ret;
+	int __attribute__ ((unused)) ret;
 	int ms = 100;
 
 	do_activate("");
@@ -1014,7 +1014,7 @@ static void do_sls(char *arg)
 static void do_test(void)
 {
 	int i = 0;
-	int ret;
+	int __attribute__ ((unused)) ret;
 	struct timeval delay;
 	int ms = 100;
 

--- a/SOURCE/diagnose-tools/testcase/run_trace/run_trace_main.cc
+++ b/SOURCE/diagnose-tools/testcase/run_trace/run_trace_main.cc
@@ -45,6 +45,7 @@ int test_run_trace_main(int argc, char *argv[])
 	int i, count = 2, type = 0, threshold = 1234;
 	int fp = 0;
 	int c;
+	ssize_t __attribute__ ((unused)) size;
 	static struct option long_options[] = {
 			{"help",     no_argument, 0,  0 },
 			{"type",     required_argument, 0,  0 },
@@ -85,7 +86,7 @@ int test_run_trace_main(int argc, char *argv[])
 		} else if (type == 1) {
 			fp = open("/proc/ali-linux/diagnose/kern/run-trace-settings", O_WRONLY);
 			if (fp != -1) {
-				write(fp, "start 1234", 11);
+				size = write(fp, "start 1234", 11);
 				close(fp);
 			}
 		} else if (type == 2) {
@@ -101,7 +102,7 @@ int test_run_trace_main(int argc, char *argv[])
 		} else if (type == 1) {
 			fp = open("/proc/ali-linux/diagnose/kern/run-trace-settings", O_WRONLY);
 			if (fp != -1) {
-				write(fp, "stop", 5);
+				size = write(fp, "stop", 5);
 				close(fp);
 			}
 		} else if (type == 2) {

--- a/SOURCE/diagnose-tools/uprobe.cc
+++ b/SOURCE/diagnose-tools/uprobe.cc
@@ -103,31 +103,31 @@ static void do_activate(const char *arg)
 	}
 
 	param_name = parse.string_value("param1-name");
-	strncpy(settings.params[0].param_name, param_name.c_str(), 255);
+	memcpy(settings.params[0].param_name, param_name.c_str(), 255);
 	settings.params[0].param_idx = parse.int_value("param1-index");
 	settings.params[0].type = parse.int_value("param1-type");
 	settings.params[0].size = parse.int_value("param1-size");
 
 	param_name = parse.string_value("param2-name");
-	strncpy(settings.params[1].param_name, param_name.c_str(), 255);
+	memcpy(settings.params[1].param_name, param_name.c_str(), 255);
 	settings.params[1].param_idx = parse.int_value("param2-index");
 	settings.params[1].type = parse.int_value("param2-type");
 	settings.params[1].size = parse.int_value("param3-size");
 
 	param_name = parse.string_value("param3-name");
-	strncpy(settings.params[2].param_name, param_name.c_str(), 255);
+	memcpy(settings.params[2].param_name, param_name.c_str(), 255);
 	settings.params[2].param_idx = parse.int_value("param3-index");
 	settings.params[2].type = parse.int_value("param3-type");
 	settings.params[2].size = parse.int_value("param3-size");
 
 	param_name = parse.string_value("param4-name");
-	strncpy(settings.params[3].param_name, param_name.c_str(), 255);
+	memcpy(settings.params[3].param_name, param_name.c_str(), 255);
 	settings.params[3].param_idx = parse.int_value("param4-index");
 	settings.params[3].type = parse.int_value("param4-type");
 	settings.params[3].size = parse.int_value("param4-size");
 
 	param_name = parse.string_value("param5-name");
-	strncpy(settings.params[4].param_name, param_name.c_str(), 255);
+	memcpy(settings.params[4].param_name, param_name.c_str(), 255);
 	settings.params[4].param_idx = parse.int_value("param5-index");
 	settings.params[4].type = parse.int_value("param5-type");
 	settings.params[4].size = parse.int_value("param5-size");


### PR DESCRIPTION
使用make tools命令编译diagnose-tools时，出现如下编译警告信息：
    warning: ignoring return value
    warning: format not a string literal and no format arguments [-Wformat-security]
    warning: variable ‘xxx’ set but not used [-Wunused-but-set-variable]
    warning: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ specified bound 255 equals destination size [-Wstringop-truncation]
本补丁优化工具代码，避免产生这些编译警告。