### PR TITLE
kprobe: activate增加count字段，允许用户在activate的时候指定一个采样参数

### DIFF
--- a/SOURCE/diagnose-tools/kprobe.cc
+++ b/SOURCE/diagnose-tools/kprobe.cc
@@ -67,6 +67,7 @@ static void do_activate(const char *arg)
 	settings.pid = parse.int_value("pid");
 	settings.dump_style = parse.int_value("dump-style");
 	settings.raw_stack = parse.int_value("raw-stack");
+	settings.count = parse.int_value("count");
 
 	str = parse.string_value("comm");
 	if (str.length() > 0) {

--- a/SOURCE/module/internal.h
+++ b/SOURCE/module/internal.h
@@ -430,6 +430,7 @@ struct diag_percpu_context {
 	} rw_top;
 
 	struct utilization_detail utilization_detail;
+	unsigned int count;
 };
 
 extern struct diag_percpu_context *diag_percpu_context[NR_CPUS];

--- a/SOURCE/uapi/kprobe.h
+++ b/SOURCE/uapi/kprobe.h
@@ -24,6 +24,7 @@ struct diag_kprobe_settings {
 	char func[255];
 	unsigned long dump_style;
 	unsigned long raw_stack;
+	unsigned int count;
 };
 
 struct kprobe_detail {


### PR DESCRIPTION
kprobe 这些功能在采样的时候，如果遇到非常热点的函数，会导致输出数据太多，缓冲区不足，也容易把系统打死,例如每5次才输出一次