### PR TITLE
修复rawstack unwind的bug

### DIFF
--- a/SOURCE/diagnose-tools/elf.cc
+++ b/SOURCE/diagnose-tools/elf.cc
@@ -308,22 +308,13 @@ bool get_symbol_in_elf(std::set<symbol> &ss, const char *path)
     symbol_sections_ctx si;
     memset(&si, 0, sizeof(si));
     if (symtab_sec) {
-        if (get_symbols_in_section(&si.symtab, elf, symtab_sec, &symtab_shdr, is_reloc) < 0) {
-            elf_end(elf);
-            close(fd);
-        }
+        get_symbols_in_section(&si.symtab, elf, symtab_sec, &symtab_shdr, is_reloc);
     }
     if (dynsym_sec) {
-        if (get_symbols_in_section(&si.symtab_in_dynsym, elf, dynsym_sec, &dynsym_shdr, is_reloc) < 0) {
-            elf_end(elf);
-            close(fd);
-        }
+        get_symbols_in_section(&si.symtab_in_dynsym, elf, dynsym_sec, &dynsym_shdr, is_reloc);
     }
     if (dynsym_sec && plt_sec) {
-        if (get_plt_symbols_in_section(&si.dynsymtab, elf, &plt) < 0) {
-            elf_end(elf);
-            close(fd);
-        }
+        get_plt_symbols_in_section(&si.dynsymtab, elf, &plt);
     }
 
     get_all_symbols(ss, &si, elf);

--- a/SOURCE/diagnose-tools/symbol.cc
+++ b/SOURCE/diagnose-tools/symbol.cc
@@ -331,6 +331,9 @@ vma* symbol_parser::find_vma(pid_t pid, size_t pc)
     if (vmit == it->second.end() || vmit->second.end < pc) {
         return NULL;
     }
+    if (vmit != it->second.begin()) {
+        --vmit;
+    }
     return &vmit->second;
 }
 

--- a/SOURCE/diagnose-tools/unwind.cc
+++ b/SOURCE/diagnose-tools/unwind.cc
@@ -267,7 +267,7 @@ struct eh_frame_hdr {
 	 * } binary_search_table[fde_count];
 	 */
 	char data[0];
-} __packed;
+} __attribute__((__packed__));
 
 int dso_data_fd(vma* dso)
 {


### PR DESCRIPTION
1. dwarf的header数据结构大小设置错
2. vma查找的范围往后多查了一个