### PR TITLE
kern: Fix insmod diagnose.ko error.

### DIFF
--- a/SOURCE/module/kernel/mutex.c
+++ b/SOURCE/module/kernel/mutex.c
@@ -621,6 +621,8 @@ static int lookup_syms(void)
 	if (orig___mutex_unlock_slowpath == NULL)
 		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.17");
 	if (orig___mutex_unlock_slowpath == NULL)
+		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.19");
+	if (orig___mutex_unlock_slowpath == NULL)
 		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath");
 	if (orig___mutex_unlock_slowpath == NULL)
 		return -EINVAL;


### PR DESCRIPTION
Signed-off-by: Fanjun Kong <bh1scw@gmail.com>

sudo diagnose-tools -v                                                             
diagnose-tools tools version 2.1-rc2
sudo diagnose-tools install                                                        
insmod: ERROR: could not insert module /usr/diagnose-tools/lib/4.19.91+//diagnose.ko: Invalid parameters
failed to install

cat /proc/kallsyms | grep __mutex_unlock_slowpath                                 ~/diagnose-tools
0000000000000000 t __mutex_unlock_slowpath.isra.19