### PR TITLE
fix build failed on Ubuntu 16.04.

### DIFF
--- a/SOURCE/diagnose-tools/Makefile
+++ b/SOURCE/diagnose-tools/Makefile
@@ -3,7 +3,7 @@ VENDER_LDFLAGS ?=
 
 arch=$(shell uname -i)
 ifeq ($(arch),x86_64)
-LDFLAGS = $(VENDER_LDFLAGS) -static-libgcc -static-libstdc++ -lgcc_eh -lunwind-x86_64 -lunwind -lelf -llzma -lz \
+LDFLAGS = $(VENDER_LDFLAGS) -static-libgcc -static-libstdc++ -lgcc_eh -lunwind-x86_64 -lunwind -lelf \
 	-L`pwd` -L/usr/lib64
 else
 LDFLAGS = $(VENDER_LDFLAGS) -static-libgcc -static-libstdc++ -L`pwd` -L/usr/lib64 -lunwind-aarch64 -lunwind -lelf -llzma -lz

--- a/SOURCE/module/Makefile
+++ b/SOURCE/module/Makefile
@@ -145,6 +145,10 @@ ifneq ($(findstring 3.10.0-1127.10.1.el7.x86_64,$(KERNEL_BUILD_PATH)),)
 	DIAG_EXTRA_CFLAGS += -DCENTOS_3_10_1127_10_1
 endif
 
+ifneq ($(findstring 4.15.0-112-generic,$(KERNEL_BUILD_PATH)),)
+	DIAG_EXTRA_CFLAGS += -DUBUNTU_1604
+endif
+
 ifneq ($(KERNELRELEASE),)
 	TARGET := diagnose
 	obj-m = $(TARGET).o

--- a/SOURCE/module/kernel/kern_entry.c
+++ b/SOURCE/module/kernel/kern_entry.c
@@ -248,7 +248,7 @@ int diag_kernel_init(void)
 
 	on_each_cpu(start_timer, NULL, 1);
 
-#if !defined(XBY_UBUNTU_1604) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
+#if !defined(XBY_UBUNTU_1604) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 	register_hotcpu_notifier(&diag_cpu_nb);
 #endif
 
@@ -314,7 +314,7 @@ void diag_kernel_exit(void)
 	struct diag_percpu_context *percpu_context;
 	struct hrtimer *timer;
 
-#if !defined(XBY_UBUNTU_1604) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
+#if !defined(XBY_UBUNTU_1604) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 	unregister_hotcpu_notifier(&diag_cpu_nb);
 #endif
 	/* cancel per-cpu hrtimer */

--- a/SOURCE/module/kernel/mutex.c
+++ b/SOURCE/module/kernel/mutex.c
@@ -41,7 +41,7 @@
 
 #include "uapi/mutex_monitor.h"
 
-#if defined(UPSTREAM_4_19_32) || defined(XBY_UBUNTU_1604)
+#if defined(UPSTREAM_4_19_32) || defined(XBY_UBUNTU_1604) || defined(UBUNTU_1604)
 int diag_mutex_init(void)
 {
 	return 0;
@@ -51,7 +51,7 @@ void diag_mutex_exit(void)
 {
 }
 #else
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 /*
  * Optimistic trylock that only works in the uncontended case. Make sure to
  * follow with a __mutex_trylock() before failing.

--- a/SOURCE/module/kernel/sched_delay.c
+++ b/SOURCE/module/kernel/sched_delay.c
@@ -47,7 +47,8 @@
 #include "uapi/sched_delay.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32) && \
-	LINUX_VERSION_CODE <= KERNEL_VERSION(4, 20, 0)
+	LINUX_VERSION_CODE <= KERNEL_VERSION(4, 20, 0) \
+	&& !defined(UBUNTU_1604)
 
 #if KERNEL_VERSION(4, 9, 0) <= LINUX_VERSION_CODE
 #define diag_last_queued ali_reserved3

--- a/SOURCE/module/kernel/utilization.c
+++ b/SOURCE/module/kernel/utilization.c
@@ -45,7 +45,7 @@
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 33)) || (KERNEL_VERSION(4, 20, 0) <= LINUX_VERSION_CODE) \
 	|| defined(CENTOS_3_10_693) || defined(CENTOS_3_10_957) \
 	|| defined(CENTOS_3_10_862) || defined(CENTOS_3_10_1062) \
-	|| defined(CENTOS_3_10_1127)
+	|| defined(CENTOS_3_10_1127) || defined(UBUNTU_1604)
 /**
  * 只支持7u
  */

--- a/SOURCE/module/net/drop_packet.c
+++ b/SOURCE/module/net/drop_packet.c
@@ -57,7 +57,7 @@
 #include "uapi/drop_packet.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(XBY_UBUNTU_1604) \
-	&& !defined(CENTOS_3_10_123_9_3)
+	&& !defined(CENTOS_3_10_123_9_3) && !defined(UBUNTU_1604)
 
 __maybe_unused static atomic64_t diag_nr_running = ATOMIC64_INIT(0);
 struct diag_drop_packet_settings drop_packet_settings;

--- a/SOURCE/module/net/ping_delay.c
+++ b/SOURCE/module/net/ping_delay.c
@@ -56,7 +56,7 @@
 #include "uapi/ping_delay.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(XBY_UBUNTU_1604) \
-	&& !defined(CENTOS_3_10_123_9_3)
+	&& !defined(CENTOS_3_10_123_9_3) && !defined(UBUNTU_1604)
 
 __maybe_unused static atomic64_t diag_nr_running = ATOMIC64_INIT(0);
 struct diag_ping_delay_settings ping_delay_settings;

--- a/SOURCE/module/pub/fs_utils.c
+++ b/SOURCE/module/pub/fs_utils.c
@@ -11,7 +11,7 @@
 
 #include <linux/fdtable.h>
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 #include <linux/sched/task.h>
 #include <linux/sched/mm.h>
 #endif


### PR DESCRIPTION
Fix build failed on Ubuntu 16.04, default kernel version: 4.15.0

Signed-off-by: Fanjun Kong <fanjun.kong@uisee.com>
Acked-by: Baoyou Xie <baoyou.xie@alibaba-inc.com>
Tested-by: Fanjun Kong <fanjun.kong@uisee.com>