### PR TITLE
Add Support for CentOS 8

### DIFF
--- a/SOURCE/module/Makefile
+++ b/SOURCE/module/Makefile
@@ -18,6 +18,25 @@ ifeq ($(EXPERIENTIAL),1)
 	DIAG_EXTRA_CFLAGS += -DEXPERIENTIAL
 endif
 
+ifneq ($(findstring el8,$(KERNEL_BUILD_PATH)),)
+	DIAG_EXTRA_CFLAGS += -DCENTOS_8U
+
+	ifneq ($(findstring 4.18.0-80,$(KERNEL_BUILD_PATH)),)
+		DIAG_EXTRA_CFLAGS += -DCENTOS_4_18_80
+	endif
+
+	ifneq ($(findstring 4.18.0-147,$(KERNEL_BUILD_PATH)),)
+		DIAG_EXTRA_CFLAGS += -DCENTOS_4_18_147
+	endif
+
+	ifneq ($(findstring 4.18.0-193,$(KERNEL_BUILD_PATH)),)
+		DIAG_EXTRA_CFLAGS += -DCENTOS_4_18_193
+	endif
+#	ifneq ($(findstring 4.18.0-193.19.1.el8_2.x86_64,$(KERNEL_BUILD_PATH)),)
+#		DIAG_EXTRA_CFLAGS += -DCENTOS_4_18_193_19_1
+#	endif
+endif
+
 ifneq ($(findstring el7.x86_64,$(KERNEL_BUILD_PATH)),)
 	DIAG_EXTRA_CFLAGS += -DCENTOS_7U
 

--- a/SOURCE/module/internal.h
+++ b/SOURCE/module/internal.h
@@ -705,9 +705,11 @@ int diag_copy_stack_frame(struct task_struct *tsk,
 	void *frame,
 	unsigned int size);
 
-#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(CENTOS_8U)
 #define synchronize_sched synchronize_rcu
+#endif
 
+#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
 static inline void do_gettimeofday(struct timeval *tv)
 {
 	struct timespec64 ts;

--- a/SOURCE/module/kernel/mutex.c
+++ b/SOURCE/module/kernel/mutex.c
@@ -51,7 +51,7 @@ void diag_mutex_exit(void)
 {
 }
 #else
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0) || defined(CENTOS_8U)
 /*
  * Optimistic trylock that only works in the uncontended case. Make sure to
  * follow with a __mutex_trylock() before failing.

--- a/SOURCE/module/kernel/sched_delay.c
+++ b/SOURCE/module/kernel/sched_delay.c
@@ -50,12 +50,16 @@
 	LINUX_VERSION_CODE <= KERNEL_VERSION(4, 20, 0) \
 	&& !defined(UBUNTU_1604)
 
+#if  defined(CENTOS_8U)
+#define diag_last_queued rh_reserved3
+#else
 #if KERNEL_VERSION(4, 9, 0) <= LINUX_VERSION_CODE
 #define diag_last_queued ali_reserved3
 #elif KERNEL_VERSION(3, 10, 0) <= LINUX_VERSION_CODE
 #define diag_last_queued rh_reserved3
 #else
 #define diag_last_queued rh_reserved[0]
+#endif
 #endif
 
 __maybe_unused static atomic64_t diag_nr_running = ATOMIC64_INIT(0);

--- a/SOURCE/module/kernel/sig_info.c
+++ b/SOURCE/module/kernel/sig_info.c
@@ -44,7 +44,7 @@ static void clean_data(void)
 	//
 }
 
-static void inspect_signal(int signum, const struct task_struct *rtask)
+static void inspect_signal(int signum, struct task_struct *rtask)
 {
 	struct task_struct *stask = current;
 	unsigned long flags;

--- a/SOURCE/module/kernel/utilization.c
+++ b/SOURCE/module/kernel/utilization.c
@@ -45,7 +45,8 @@
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 33)) || (KERNEL_VERSION(4, 20, 0) <= LINUX_VERSION_CODE) \
 	|| defined(CENTOS_3_10_693) || defined(CENTOS_3_10_957) \
 	|| defined(CENTOS_3_10_862) || defined(CENTOS_3_10_1062) \
-	|| defined(CENTOS_3_10_1127) || defined(UBUNTU_1604)
+	|| defined(CENTOS_3_10_1127) || defined(UBUNTU_1604) \
+	|| defined(CENTOS_8U)
 /**
  * 只支持7u
  */

--- a/SOURCE/module/net/drop_packet.c
+++ b/SOURCE/module/net/drop_packet.c
@@ -57,7 +57,7 @@
 #include "uapi/drop_packet.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(XBY_UBUNTU_1604) \
-	&& !defined(CENTOS_3_10_123_9_3) && !defined(UBUNTU_1604)
+	&& !defined(CENTOS_3_10_123_9_3) && !defined(UBUNTU_1604) && !defined(CENTOS_8U)
 
 __maybe_unused static atomic64_t diag_nr_running = ATOMIC64_INIT(0);
 struct diag_drop_packet_settings drop_packet_settings;

--- a/SOURCE/module/net/ping_delay.c
+++ b/SOURCE/module/net/ping_delay.c
@@ -56,7 +56,7 @@
 #include "uapi/ping_delay.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) && !defined(XBY_UBUNTU_1604) \
-	&& !defined(CENTOS_3_10_123_9_3) && !defined(UBUNTU_1604)
+	&& !defined(CENTOS_3_10_123_9_3) && !defined(UBUNTU_1604) && !defined(CENTOS_8U)
 
 __maybe_unused static atomic64_t diag_nr_running = ATOMIC64_INIT(0);
 struct diag_ping_delay_settings ping_delay_settings;

--- a/SOURCE/module/pub/stack.c
+++ b/SOURCE/module/pub/stack.c
@@ -82,7 +82,7 @@ copy_stack_frame(const void __user *fp, struct stackframe *frame)
 	int ret = 0;
 	unsigned long data[2];
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0) && !(defined(CENTOS_8U))
 	if (!access_ok(VERIFY_READ, fp, sizeof(*frame)))
 #else
 	if (!access_ok(fp, sizeof(*frame)))
@@ -489,7 +489,7 @@ copy_stack_frame(const void __user *fp, struct stack_frame_user *frame)
 {
 	int ret;
 
-#if KERNEL_VERSION(5, 0, 0) >= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 0, 0) >= LINUX_VERSION_CODE && !(defined(CENTOS_8U))
 	if (!access_ok(VERIFY_READ, fp, sizeof(*frame)))
 		return 0;
 #endif

--- a/SOURCE/module/pub/trace_point.c
+++ b/SOURCE/module/pub/trace_point.c
@@ -85,7 +85,7 @@ int diag_unregister_cb_sys_enter(cb_sys_enter cb, void *data)
 	up_write(&sys_enter_sem);
 
 	if (found) {
-#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(CENTOS_8U)
 		synchronize_rcu();
 #else
 		synchronize_sched();

--- a/SOURCE/module/symbol.c
+++ b/SOURCE/module/symbol.c
@@ -29,7 +29,14 @@ struct list_head *orig_ptype_all;
 
 void (*orig___show_regs)(struct pt_regs *regs, int all);
 #if !defined(DIAG_ARM64)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0) || defined(CENTOS_4_18_193)
+unsigned int (*orig_stack_trace_save_tsk)(struct task_struct *task,
+                                  unsigned long *store, unsigned int size,
+                                  unsigned int skipnr);
+unsigned int (*orig_stack_trace_save_user)(unsigned long *store, unsigned int size);
+#else
 void (*orig_save_stack_trace_user)(struct stack_trace *trace);
+#endif
 #endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
 void (*orig___do_page_fault)(struct pt_regs *regs,
@@ -111,7 +118,7 @@ static int lookup_syms(void)
 #else
 	LOOKUP_SYMS(text_poke_bp);
 #endif /* LINUX_VERSION_CODE */
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 0, 0)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 0, 0) || defined(CENTOS_4_18_193)
 	LOOKUP_SYMS(stack_trace_save_tsk);
 	LOOKUP_SYMS(stack_trace_save_user);
 #else

--- a/SOURCE/module/symbol.h
+++ b/SOURCE/module/symbol.h
@@ -32,7 +32,14 @@ extern void (*orig___show_regs)(struct pt_regs *regs, int all);
 extern struct list_head *orig_ptype_all;
 
 #if !defined(DIAG_ARM64)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0) || defined(CENTOS_4_18_193)
+extern unsigned int (*orig_stack_trace_save_tsk)(struct task_struct *task,
+				  unsigned long *store, unsigned int size,
+				  unsigned int skipnr);
+extern unsigned int (*orig_stack_trace_save_user)(unsigned long *store, unsigned int size);
+#else
 extern void (*orig_save_stack_trace_user)(struct stack_trace *trace);
+#endif
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)


### PR DESCRIPTION
This pr add support for CentOS 8, 8.1, 8.2
    
For the following files:
    
    SOURCE/module/kernel/utilization.c
    SOURCE/module/net/drop_packet.c
    SOURCE/module/net/ping_delay.c
    
we just add `&& !defined(CENTOS_8U)`, Maybe need more work.