### PR TITLE
module: fix insmod diagnose.ko error

### DIFF
--- a/SOURCE/module/kernel/mutex.c
+++ b/SOURCE/module/kernel/mutex.c
@@ -611,6 +611,8 @@ static int lookup_syms(void)
 	
 	orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.0");
 	if (orig___mutex_unlock_slowpath == NULL)
+		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.12");
+	if (orig___mutex_unlock_slowpath == NULL)
 		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.14");
 	if (orig___mutex_unlock_slowpath == NULL)
 		orig___mutex_unlock_slowpath = (void *)__kallsyms_lookup_name("__mutex_unlock_slowpath.isra.15");


### PR DESCRIPTION
On my centos8.1 Box. insert module will return error.

Because the symbol is the following:

```
[root@localhost diagnose-tools]# cat /proc/kallsyms | grep __mutex_unlock_slowpath
ffffffff92626c40 t __mutex_unlock_slowpath.isra.12
```

This patch fix that.

Signed-off-by: Wang Long <w@laoqinren.net>