### PR TITLE
module: fix build error for centos8

### DIFF
--- a/SOURCE/module/symbol.c
+++ b/SOURCE/module/symbol.c
@@ -26,6 +26,9 @@ void *(*orig_text_poke_bp)(void *addr, const void *opcode,
 		size_t len, void *handler);
 #endif
 
+#if defined(CENTOS_8U)
+void (*orig_save_stack_trace_tsk)(struct task_struct *tsk, struct stack_trace *trace);
+#endif
 struct list_head *orig_ptype_all;
 
 void (*orig___show_regs)(struct pt_regs *regs, int all);
@@ -127,6 +130,10 @@ static int lookup_syms(void)
 	LOOKUP_SYMS(save_stack_trace_user);
 #endif
 #endif /* DIAG_ARM64 */
+
+#if defined(CENTOS_8U)
+	LOOKUP_SYMS(save_stack_trace_tsk);
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 33)
 	orig_runqueues = (void *)__kallsyms_lookup_name("per_cpu__runqueues");

--- a/SOURCE/module/symbol.h
+++ b/SOURCE/module/symbol.h
@@ -29,6 +29,9 @@ extern void *(*orig_text_poke_smp)(void *, const void *, size_t);
 extern void *(*orig_text_poke_bp)(void *addr, const void *opcode, size_t len, void *handler);
 #endif
 
+#if defined(CENTOS_8U)
+extern void (*orig_save_stack_trace_tsk)(struct task_struct *tsk, struct stack_trace *trace);
+#endif
 extern void (*orig___show_regs)(struct pt_regs *regs, int all);
 extern struct list_head *orig_ptype_all;
 


### PR DESCRIPTION
This commit 4b48c437(kern: Add look up symbol: save_stack_trace_tsk)
break the diagnose module on centos8.
```
 CC [M]  /root/diagnose-tools/SOURCE/module/net/net_bandwidth.o
  LD [M]  /root/diagnose-tools/SOURCE/module/diagnose.o
  Building modules, stage 2.
  MODPOST 1 modules
WARNING: "orig_save_stack_trace_tsk" [/root/diagnose-tools/SOURCE/module/diagnose.ko] undefined!
  CC      /root/diagnose-tools/SOURCE/module/diagnose.mod.o
  LD [M]  /root/diagnose-tools/SOURCE/module/diagnose.ko
make[2]: Leaving directory '/usr/src/kernels/4.18.0-193.19.1.el8_2.x86_64'
strip --strip-debug diagnose.ko
make[1]: Leaving directory '/root/diagnose-tools/SOURCE/module'
mkdir -p build/lib/`uname -r`/
/bin/cp -f SOURCE/module/diagnose.ko build/lib/`uname -r`/
```
The kernel for centos8 have the save_stack_trace_tsk function.
```
[root@localhost ~]# grep save_stack_trace_tsk /proc/kallsyms
ffffffff9ac300d0 T save_stack_trace_tsk
ffffffff9bd834c0 r __ksymtab_save_stack_trace_tsk
ffffffff9bd91f63 r __kstrtab_save_stack_trace_tsk
```
This patch fix it.

Signed-off-by: Wang Long <w@laoqinren.net>