### PR TITLE
module: remove /proc/ali-linux/ and /proc/ali-linux/diagnose/* interface when unload the module

### DIFF
--- a/SOURCE/module/entry.c
+++ b/SOURCE/module/entry.c
@@ -257,12 +257,12 @@ int diag_linux_proc_init(void)
 	int ret;
 
 	pe = diag_proc_mkdir("ali-linux", NULL);
-	//if (!pe)
-	//	return -ENOMEM;
+	if (!pe)
+		return -ENOMEM;
 
 	pe = diag_proc_mkdir("ali-linux/diagnose", NULL);
-	//if (!pe)
-	//	return -ENOMEM;
+	if (!pe)
+		return -ENOMEM;
 
 	ret = init_diag_trace_file(&controller_file,
 			"ali-linux/diagnose/controller",
@@ -280,9 +280,9 @@ out_controller_file:
 
 void diag_linux_proc_exit(void)
 {
-	//remove_proc_entry("ali-linux/diagnose", NULL);
-	//remove_proc_entry("ali-linux", NULL);
 	destroy_diag_trace_file(&controller_file);
+	remove_proc_entry("ali-linux/diagnose", NULL);
+	remove_proc_entry("ali-linux", NULL);
 }
 
 unsigned long (*__kallsyms_lookup_name)(const char *name);
@@ -552,9 +552,6 @@ static void __exit diagnosis_exit(void)
 	if (sys_enter_hooked)
 		diag_unhook_sys_enter();
 
-	diag_linux_proc_exit();
-	msleep(20);
-
 	diag_dev_cleanup();
 
 	synchronize_sched();
@@ -592,6 +589,9 @@ static void __exit diagnosis_exit(void)
 	msleep(20);
 
 	alidiagnose_symbols_exit();
+	msleep(20);
+
+	diag_linux_proc_exit();
 	msleep(20);
 
 	synchronize_sched();

--- a/SOURCE/module/io/io_entry.c
+++ b/SOURCE/module/io/io_entry.c
@@ -95,5 +95,5 @@ void diag_io_exit(void)
 	diag_vfs_exit();
 	diag_nvme_exit();
 
-	//remove_proc_entry("ali-linux/diagnose/io", NULL);
+	remove_proc_entry("ali-linux/diagnose/io", NULL);
 }

--- a/SOURCE/module/kernel/kern_entry.c
+++ b/SOURCE/module/kernel/kern_entry.c
@@ -356,5 +356,5 @@ void diag_kernel_exit(void)
 	diag_irq_delay_exit();
 	diag_irq_stats_exit();
 
-	//remove_proc_entry("ali-linux/diagnose/kern", NULL);
+	remove_proc_entry("ali-linux/diagnose/kern", NULL);
 }

--- a/SOURCE/module/mm/mm_entry.c
+++ b/SOURCE/module/mm/mm_entry.c
@@ -87,6 +87,6 @@ void diag_mm_exit(void)
 	diag_memory_leak_exit();
 	diag_mm_page_fault_exit();
 	diag_alloc_top_exit();
-    //remove_proc_entry("ali-linux/diagnose/mm", NULL);
+	remove_proc_entry("ali-linux/diagnose/mm", NULL);
 }
 

--- a/SOURCE/module/net/net_entry.c
+++ b/SOURCE/module/net/net_entry.c
@@ -99,5 +99,5 @@ void diag_net_exit(void)
 	diag_net_packet_corruption_exit();
 	diag_net_redis_ixgbe_exit();
 	diag_net_net_bandwidth_exit();
-	//remove_proc_entry("ali-linux/diagnose/net", NULL);
+	remove_proc_entry("ali-linux/diagnose/net", NULL);
 }


### PR DESCRIPTION
When the diagnose.ko loaded, we create /proc/ali-linux/ and
/proc/ali-linux/diagnose/*.  At the module exit function we
should remove these directories and files.

This patch uncomment the code and move diag_linux_proc_exit at
the end of diag_io_exit(we should remove top directory at last).

Signed-off-by: Wang Long <w@laoqinren.net>