### PR TITLE
module: use LOOKUP_SYMS_NORET and LOOKUP_SYMS to find symbol address

### DIFF
--- a/SOURCE/module/kernel/load.c
+++ b/SOURCE/module/kernel/load.c
@@ -385,8 +385,8 @@ long diag_ioctl_load_monitor(unsigned int cmd, unsigned long arg)
 
 int diag_load_init(void)
 {
-	orig_avenrun_r = (void *)__kallsyms_lookup_name("avenrun_r");
-	orig_avenrun = (void *)__kallsyms_lookup_name("avenrun");
+	LOOKUP_SYMS_NORET(avenrun_r);
+	LOOKUP_SYMS_NORET(avenrun);
 
 	init_mm_tree(&mm_tree);
 	init_diag_variant_buffer(&load_monitor_variant_buffer, 1 * 1024 * 1024);

--- a/SOURCE/module/symbol.c
+++ b/SOURCE/module/symbol.c
@@ -158,16 +158,15 @@ static int lookup_syms(void)
 #endif
 	LOOKUP_SYMS(task_statm);
 
-	orig_d_find_any_alias = (void *)__kallsyms_lookup_name("d_find_any_alias");
-
-	orig_find_task_by_vpid = (void *)__kallsyms_lookup_name("find_task_by_vpid");
-	orig_find_task_by_pid_ns = (void *)__kallsyms_lookup_name("find_task_by_pid_ns");
-	orig_get_task_type = (void *)__kallsyms_lookup_name("get_task_type");
-	orig_kernfs_name = (void *)__kallsyms_lookup_name("kernfs_name");
-	orig_root_cpuacct = (void *)__kallsyms_lookup_name("root_cpuacct");
-	orig_css_next_descendant_pre = (void *)__kallsyms_lookup_name("css_next_descendant_pre");
-	orig_cpuacct_subsys = (void *)__kallsyms_lookup_name("cpuacct_subsys");
-	orig_css_get_next = (void *)__kallsyms_lookup_name("css_get_next");
+	LOOKUP_SYMS_NORET(d_find_any_alias);
+	LOOKUP_SYMS_NORET(find_task_by_vpid);
+	LOOKUP_SYMS_NORET(find_task_by_pid_ns);
+	LOOKUP_SYMS_NORET(get_task_type);
+	LOOKUP_SYMS_NORET(kernfs_name);
+	LOOKUP_SYMS_NORET(root_cpuacct);
+	LOOKUP_SYMS_NORET(css_next_descendant_pre);
+	LOOKUP_SYMS_NORET(cpuacct_subsys);
+	LOOKUP_SYMS_NORET(css_get_next);
 
 	return 0;
 }
@@ -209,15 +208,8 @@ int alidiagnose_symbols_init(void)
 	if (ret)
 		return ret;
 
-	ret = -EINVAL;
-
-	orig___show_regs = (void *)__kallsyms_lookup_name("__show_regs");
-	if (!orig___show_regs)
-		return ret;
-
-	orig_ptype_all = (void *)__kallsyms_lookup_name("ptype_all");
-	if (!orig_ptype_all)
-                return ret;
+	LOOKUP_SYMS(__show_regs);
+	LOOKUP_SYMS(ptype_all);
 
 	return 0;
 }


### PR DESCRIPTION
By using LOOKUP_SYMS_NORET, we can easily know the symbols which
are not exist.

In my Centos 8 box:

```
[root@localhost diagnose-tools]# dmesg -C; diagnose-tools install; dmesg ; diagnose-tools uninstall
installed successfully
[13858.173140] kallsyms_lookup_name: get_task_type
[13858.202442] kallsyms_lookup_name: cpuacct_subsys
[13858.215090] kallsyms_lookup_name: css_get_next
[13858.274083] kallsyms_lookup_name: avenrun_r
[13858.364500] diagnose-tools in diagnosis_init
uninstalled successfully
```
Signed-off-by: Wang Long <w@laoqinren.net>