### PR TITLE
module: fix build error on centos7 (3.10.0-862.9.1.el7)

### DIFF
--- a/SOURCE/module/Makefile
+++ b/SOURCE/module/Makefile
@@ -52,8 +52,8 @@ ifneq ($(findstring el7.x86_64,$(KERNEL_BUILD_PATH)),)
 		DIAG_EXTRA_CFLAGS += -DCENTOS_3_10_693
 	endif
 
-	ifneq ($(findstring 3.10.0-862.el7.x86_64,$(KERNEL_BUILD_PATH)),)
-		DIAG_EXTRA_CFLAGS += -DCENTOS_3_10_862 -DCENTOS_7U
+	ifneq ($(findstring 3.10.0-862,$(KERNEL_BUILD_PATH)),)
+		DIAG_EXTRA_CFLAGS += -DCENTOS_3_10_862
 	endif
 
 	ifneq ($(findstring 3.10.0-957,$(KERNEL_BUILD_PATH)),)


### PR DESCRIPTION
If the kenel version is 3.10.0-862.9.1.el7, we should not build the
utilization function in diagnose.ko.

This patch fix it.

This patch also delete duplicate CENTOS_7U definition.

Signed-off-by: Wang Long <w@laoqinren.net>