### PR TITLE
module: fix fs-cache file name error

### DIFF
--- a/SOURCE/module/pub/fs_utils.c
+++ b/SOURCE/module/pub/fs_utils.c
@@ -30,7 +30,7 @@ void diag_inode_short_name(struct inode *inode, char *path_name, int size)
 	dentry = orig_d_find_any_alias(inode);
 	if (dentry) {
 		strncpy(path_name, dentry->d_name.name, min(size, (int)dentry->d_name.len));
-		path_name[size - 1] = 0;
+		path_name[min(size - 1, (int)dentry->d_name.len)] = 0;
 		dput(dentry);
 	}
 }


### PR DESCRIPTION
when using the command "diagnose-tools fs-cache --report" to show
file pagecache, The file name you see is longer than it is.
End the string correctly and fix the problem.

Signed-off-by: Long Li <lonuxli.64@gmail.com>