### PR TITLE
add setns when parse elf file in mount namespace

### DIFF
--- a/SOURCE/diagnose-tools/attach.cc
+++ b/SOURCE/diagnose-tools/attach.cc
@@ -1,0 +1,78 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <syscall.h>
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "internal.h"
+#include "attach.h"
+
+
+static int global_mnt_ns_fd = -1;
+static char global_mnt_ns_name[NS_NAME_LEN];
+static char g_mnt_ns_name[128];
+
+int init_global_env(void) {
+    struct utsname utsname;
+    int ret = uname(&utsname);
+    if (ret < 0) {
+        return -1;
+    }
+
+    if (readlink("/proc/1/ns/mnt", g_mnt_ns_name, sizeof(g_mnt_ns_name)) < 0) {
+        return -1;
+    }
+
+    ret = readlink("/proc/1/ns/mnt", global_mnt_ns_name, NS_NAME_LEN);
+    if (ret <= 0) {
+        return -1;
+    } else {
+        global_mnt_ns_fd = open("/proc/1/ns/mnt", 0);
+        if (global_mnt_ns_fd < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int attach_mount_namespace(int pid, const char *mnt_ns_name) {
+    int mntfd = -1;
+    int ret = -1;
+
+    char mnt_ns_path[NS_PATH_LEN];
+
+    if (is_linux_2_6_x()) {
+        return -1;
+    }
+
+    snprintf(mnt_ns_path, sizeof(mnt_ns_path), "/proc/%d/ns/mnt", pid);
+    if (strcmp(mnt_ns_name, global_mnt_ns_name) != 0 && global_mnt_ns_fd > 0) {
+        mntfd = open(mnt_ns_path, O_RDONLY);
+        if (mntfd < 0) {
+            return -1;
+        }
+        ret = syscall(__NR_setns, mntfd, 0);
+        if (ret < 0) {
+            close(mntfd);
+            return -1;
+        }
+    }
+    return mntfd;
+}
+
+void detach_mount_namespace(int mntfd) {
+    if (is_linux_2_6_x()) {
+        return;
+    }
+    if (mntfd >= 0) {
+        close(mntfd);
+        if (syscall(__NR_setns, global_mnt_ns_fd, 0) < 0) {
+            exit(-1);
+        }
+    }
+}

--- a/SOURCE/diagnose-tools/attach.h
+++ b/SOURCE/diagnose-tools/attach.h
@@ -1,0 +1,8 @@
+#ifndef __ATTACH_H__
+#define __ATTACH_H__
+#define NS_NAME_LEN 128
+#define NS_PATH_LEN 128
+int init_global_env(void);
+int attach_mount_namespace(int pid, const char *mnt_ns_name);
+void detach_mount_namespace(int mntfd);
+#endif

--- a/SOURCE/diagnose-tools/elf.h
+++ b/SOURCE/diagnose-tools/elf.h
@@ -17,6 +17,6 @@
 
 #include "symbol.h"
 
-bool get_symbol_in_elf(std::set<symbol> &ss, const char *path);
+bool get_symbol_in_elf(std::set<symbol> &ss, const char *path, int pid, const char *mnt_ns_name);
 bool search_symbol(const std::set<symbol> &ss, symbol &sym);
 #endif

--- a/SOURCE/diagnose-tools/symbol.h
+++ b/SOURCE/diagnose-tools/symbol.h
@@ -32,6 +32,7 @@ struct elf_file {
     size_t		  table_data;
     std::string filename;
     std::string buildid;
+    std::string mnt_ns_name;
     int type;
 
     // TODO get builid from elf header or build hash for elf
@@ -56,11 +57,10 @@ struct elf_file {
     }
 
     bool operator<  (const elf_file &rhs) const {
+        if (buildid == rhs.buildid) {
+            return mnt_ns_name < rhs.mnt_ns_name;
+        }
         return buildid < rhs.buildid;
-    }
-
-    bool operator> (const elf_file &rhs) const {
-        return buildid > rhs.buildid;
     }
 };
 
@@ -76,10 +76,6 @@ struct symbol {
     void reset(size_t va) { start = end = 0; ip = va; }
     bool operator< (const symbol &sym) const {
         return sym.ip < start;
-    }
-    
-    bool operator> (const symbol &sym) const {
-        return sym.ip > end;
     }
 };
 
@@ -126,10 +122,6 @@ struct vma {
     }
 };
 
-static inline bool operator==(const vma &lhs, const vma &rhs) {
-    return lhs.start == rhs.start && lhs.end == rhs.end && lhs.name == rhs.name;
-}
-
 class symbol_parser {
 private:
     typedef std::map<size_t, vma> proc_vma;
@@ -156,7 +148,7 @@ public:
 
 private:
     bool load_pid_maps(int pid);
-    bool load_elf(const elf_file& file);
+    bool load_elf(pid_t pid, const elf_file& file);
     bool load_perf_map(int pid, int pid_ns);
 };
 


### PR DESCRIPTION
当前解析ELF符号表的时候，是直接open /proc/pid/maps里面的文件名来解析ELF的
在docker等容器环境，/proc/pid/maps里面的文件路径是容器内路径，需要转换成容器外路径或者是setns进容器内再open文件

在打开文件前，增加setns，再打开文件，就能做到打开正确的文件了。
注意：setns不能用于多线程环境