### PR TITLE
class_destroy contains class_unregister, so delete duplicate code

### DIFF
--- a/SOURCE/module/chr_dev.c
+++ b/SOURCE/module/chr_dev.c
@@ -242,7 +242,6 @@ void diag_dev_cleanup(void)
     }
 
     if (diag_dev_class != NULL) {
-        class_unregister(diag_dev_class);
         class_destroy(diag_dev_class);
     }
 


### PR DESCRIPTION
class_destroy contains class_unregister, repeated calls that cause problems
https://github.com/alibaba/diagnose-tools/issues/65