### PR TITLE
fs: rw-top: handle the count field of vfs_fsync

### DIFF
--- a/SOURCE/module/fs/rw_top.c
+++ b/SOURCE/module/fs/rw_top.c
@@ -340,12 +340,7 @@ static int kprobe_vfs_write_pre(struct kprobe *p, struct pt_regs *regs)
 static int kprobe_vfs_fsync_range_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	struct file *file = (void *)ORIG_PARAM1(regs);
-	loff_t start = ORIG_PARAM2(regs);
-	loff_t end = ORIG_PARAM3(regs);
-	size_t count;
-
-	count = (end > start) ? (end - start) : 0;
-	hook_rw(RW_WRITE, file, count);
+	hook_rw(RW_WRITE, file, 1);
 
 	return 0;
 }


### PR DESCRIPTION
vfs_fsync may be passed in ULONGMAX, so count is meaningless; we pay
more attention to the calling frequency of fdatasync, which can be seen
from the flame graph, so the count is changed to 1.