### PR TITLE
fix make deps error

### DIFF
--- a/SOURCE/diagnose-tools/java_agent/perf-map-agent.c
+++ b/SOURCE/diagnose-tools/java_agent/perf-map-agent.c
@@ -66,14 +66,6 @@ char *frame_annotation(bool inlined) {
     return annotate_java_frames ? (inlined ? "_[i]" : "_[j]") : "";
 }
 
-static int get_line_number(jvmtiLineNumberEntry *table, jint entry_count, jlocation loc) {
-  int i;
-  for (i = 0; i < entry_count; i++)
-    if (table[i].start_location > loc) return table[i - 1].line_number;
-
-  return -1;
-}
-
 void class_name_from_sig(char *dest, size_t dest_size, const char *sig) {
     if ((clean_class_names || dotted_class_names) && sig[0] == 'L') {
         const char *src = clean_class_names ? sig + 1 : sig;


### PR DESCRIPTION
when i run `make deps`, the error came out like this:
amd_server@ubuntu: ~/workspace/diagnose-tools# sudo make deps
cd SOURCE/diagnose-tools/java_agent; make
make[1]: Entering directory '/home/ubuntu/workspace/diagnose-tools/SOURCE/diagnose-tools/java_agent'
cc -fPIC -static-libgcc -static-libstdc++ -Wall -O2 -I . -I /usr/lib/jvm/java-1.11.0-openjdk-amd64/include/ -I /usr/lib/jvm/java-1.11.0-openjdk-amd64/include/linux/ -I/include -I/include/linux   -c -o perf-map-agent.o perf-map-agent.c
perf-map-agent.c:69:12: warning: ‘get_line_number’ defined but not used [-Wunused-function]
   69 | static int get_line_number(jvmtiLineNumberEntry *table, jint entry_count, jlocation loc) {
      |            ^~~~~~~~~~~~~~~
cc -fPIC -static-libgcc -static-libstdc++ -Wall -O2 -I . -I /usr/lib/jvm/java-1.11.0-openjdk-amd64/include/ -I /usr/lib/jvm/java-1.11.0-openjdk-amd64/include/linux/ -I/include -I/include/linux   -c -o perf-map-file.o perf-map-file.c
cc -O2 -shared -static-libgcc -static-libstdc++ perf-map-agent.o perf-map-file.o -o libperfmap.so
make[1]: Leaving directory '/home/ubuntu/workspace/diagnose-tools/SOURCE/diagnose-tools/java_agent'
sh ./vender/deps.sh

it's a static function, and not used in the c source file. so i remove it, then it can build pass.

below is my machine info:
Linux server 5.8.0-40-generic #45~20.04.1-Ubuntu SMP Fri Jan 15 11:35:04 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
gcc version:
amd_server@148ubuntu: ~/workspace/tmp/diagnose-tools# gcc --version
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.

Signed-off-by: Hui Su <sh_def@163.com>