### PR TITLE
Update sched_delay.c

### DIFF
--- a/SOURCE/module/kernel/sched_delay.c
+++ b/SOURCE/module/kernel/sched_delay.c
@@ -51,7 +51,7 @@
 	&& !defined(UBUNTU_1604)
 
 #if  defined(CENTOS_8U)
-#define diag_last_queued rh_reserved3
+#define diag_last_queued rh_reserved2
 #else
 #if KERNEL_VERSION(4, 9, 0) <= LINUX_VERSION_CODE
 #define diag_last_queued ali_reserved3


### PR DESCRIPTION
rh_reserved3 -> RH_KABI_USE(3, const cpumask_t  *cpus_ptr)
rh_reserved4 -> *task_struct_rh;
rh_reserved3 and rh_reserved4 is used since 4.18.0-240 in CentOS8