### PR TITLE
Make SHF_COMPRESSED use contingent on its existence

### DIFF
--- a/SOURCE/module/chr_dev.c
+++ b/SOURCE/module/chr_dev.c
@@ -174,6 +174,7 @@ static long diag_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
         break;
     case DIAG_IOCTL_TYPE_RW_SEM:
         ret = diag_ioctl_rw_sem(nr, arg);
+        break;
     case DIAG_IOCTL_TYPE_RSS_MONITOR:
         ret = diag_ioctl_rss_monitor(nr, arg);
         break;

--- a/SOURCE/module/kernel/sched_delay.c
+++ b/SOURCE/module/kernel/sched_delay.c
@@ -46,11 +46,9 @@
 
 #include "uapi/sched_delay.h"
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32) && \
-	LINUX_VERSION_CODE <= KERNEL_VERSION(4, 20, 0) \
-	&& !defined(UBUNTU_1604)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32)  && !defined(UBUNTU_1604)
 
-#if defined(ALIOS_4000_009)
+#if defined(ALIOS_4000)
 static unsigned long *get_last_queued_addr(struct task_struct *p)
 {
 	/**
@@ -61,6 +59,8 @@ static unsigned long *get_last_queued_addr(struct task_struct *p)
 #else
 #if  defined(CENTOS_8U)
 #define diag_last_queued rh_reserved2
+#elif defined(ALIOS_5000)
+#define diag_last_queued ali_diag_reserved3
 #elif KERNEL_VERSION(4, 9, 0) <= LINUX_VERSION_CODE
 #define diag_last_queued ali_reserved3
 #elif KERNEL_VERSION(3, 10, 0) <= LINUX_VERSION_CODE

--- a/SOURCE/module/stub.c
+++ b/SOURCE/module/stub.c
@@ -32,1238 +32,236 @@
 #include "uapi/kprobe.h"
 #include "uapi/mm_leak.h"
 
-int __weak diag_net_init(void)
-{
-	return 0;
-}
 
-void __weak diag_net_exit(void)
-{
-}
-
-int __weak diag_net_packet_corruption_init(void)
-{
-	return 0;
-}
-
-void __weak diag_net_packet_corruption_exit(void)
-{
-	//
-}
-
-int __weak diag_nvme_init(void)
-{
-	return 0;
-}
-
-void __weak diag_nvme_exit(void)
-{
-}
-
-int __weak alidiagnose_xby_debug_init(void)
-{
-	return 0;
-}
-
-void __weak alidiagnose_xby_debug_exit(void)
-{
-}
-
-int __weak diag_stack_trace_init(void)
-{
-	return 0;
-}
-
-void __weak diag_stack_trace_exit(void)
-{
-	//
-}
-
-int __weak diag_irq_stats_init(void)
-{
-	return 0;
-}
-
-void __weak diag_irq_stats_exit(void)
-{
-	//
-}
-
-int __weak diag_irq_delay_init(void)
-{
-	return 0;
-}
-
-void __weak diag_irq_delay_exit(void)
-{
-	//
-}
-
-int __weak diag_sched_delay_init(void)
-{
-	return 0;
-}
-
-void __weak diag_sched_delay_exit(void)
-{
-	//
-}
-
-int __weak diag_load_init(void)
-{
-	return 0;
-}
-
-void __weak diag_load_exit(void)
-{
-	//
-}
-
-int __weak diag_exit_init(void)
-{
-	return 0;
-}
-
-void __weak diag_exit_exit(void)
-{
-	//
-}
-
-int __weak diag_sys_delay_init(void)
-{
-	return 0;
-}
-
-void __weak diag_sys_delay_exit(void)
-{
-	//
-}
-
-int __weak diag_runq_info_init(void)
-{
-	return 0;
-}
-
-void __weak diag_runq_info_exit(void)
-{
-	//
-}
-
-int __weak diag_rcu_init(void)
-{
-	return 0;
-}
-
-void __weak diag_rcu_exit(void)
-{
-	//
-}
-
-int __weak diag_sys_loop_init(void)
-{
-	return 0;
-}
-
-void __weak diag_sys_loop_exit(void)
-{
-	//
-}
-
-int __weak diag_mutex_init(void)
-{
-	return 0;
-}
-
-void __weak diag_mutex_exit(void)
-{
-	//
-}
-
-int __weak diag_timer_init(void)
-{
-	return 0;
-}
-
-void __weak diag_timer_exit(void)
-{
-	//
-}
-
-int __weak diag_exec_init(void)
-{
-	return 0;
-}
-
-void __weak diag_exec_exit(void)
-{
-	//
-}
-
-int __weak diag_kern_demo_init(void)
-{
-	return 0;
-}
-
-void __weak diag_kern_demo_exit(void)
-{
-	//
-}
-
-int __weak diag_sys_cost_init(void)
-{
-	return 0;
-}
-
-void __weak diag_sys_cost_exit(void)
-{
-	//
-}
-
-int __weak diag_task_time_init(void)
-{
-	return 0;
-}
-
-void __weak diag_task_time_exit(void)
-{
-	//
-}
-
-void __weak sys_loop_timer(struct diag_percpu_context *context)
-{
-	//
-}
-
-void __weak kern_task_runs_timer(struct diag_percpu_context *context)
-{
-	//
-}
-
-void __weak perf_timer(struct diag_percpu_context *context)
-{
-	//
-}
-
-void __weak utilization_timer(struct diag_percpu_context *context)
-{
-	//
-}
-
-int __weak diag_pupil_init(void)
-{
-	return 0;
-}
-
-void __weak diag_pupil_exit(void)
-{
-	//
-}
-
-int __weak diag_alloc_page_init(void)
-{
-	return 0;
-}
-
-void __weak diag_alloc_page_exit(void)
-{
-	//
-}
-
-int __weak diag_memory_leak_init(void)
-{
-	return 0;
-}
-
-void __weak diag_memory_leak_exit(void)
-{
-	//
-}
-
-int __weak diag_tcp_retrans_init(void)
-{
-	return 0;
-}
-
-void __weak diag_tcp_retrans_exit(void)
-{
-	//
-}
-
-int __weak diag_net_drop_packet_init(void)
-{
-	return 0;
-}
-
-void __weak diag_net_drop_packet_exit(void)
-{
-	//
-}
-
-int __weak diag_net_reqsk_init(void)
-{
-	return 0;
-}
-
-void __weak diag_net_reqsk_exit(void)
-{
-	//
-}
-
-int __weak diag_bio_init(void)
-{
-	return 0;
-}
-
-void __weak diag_bio_exit(void)
-{
-	//
-}
-
-int __weak diag_blk_dev_init(void)
-{
-	return 0;
-}
-
-void __weak diag_blk_dev_exit(void)
-{
-	//
-}
-
-int __weak diag_vfs_init(void)
-{
-	return 0;
-}
-
-void __weak diag_vfs_exit(void)
-{
-	//
-}
-
-int __weak diag_task_runs_init(void)
-{
-	return 0;
-}
-
-void __weak diag_task_runs_exit(void)
-{
-	//
-}
-
-int __weak diag_fs_init(void)
-{
-	return 0;
-}
-
-void __weak diag_fs_exit(void)
-{
-}
-
-int __weak diag_kern_perf_init(void)
-{
-	return 0;
-}
-
-void __weak diag_kern_perf_exit(void)
-{
-}
-
-int __weak diag_run_trace_init(void)
-{
-	return 0;
-}
-
-void __weak diag_run_trace_exit(void)
-{
-	//
-}
-
-int __weak diag_lock_init(void)
-{
-	return 0;
-}
-
-void __weak diag_lock_exit(void)
-{
-}
-
-int __weak diag_mm_page_fault_init(void)
-{
-	return 0;
-}
-
-void __weak diag_mm_page_fault_exit(void)
-{
-}
-
-int __weak diag_alloc_top_init(void)
-{
-	return 0;
-}
-
-void __weak diag_alloc_top_exit(void)
-{
-	//
-}
-
-int __weak diag_net_redis_ixgbe_init(void)
-{
-	return 0;
-}
-
-void __weak diag_net_redis_ixgbe_exit(void)
-{
-	//
-}
-
-int __weak diag_rw_top_init(void)
-{
-	return 0;
-}
-
-void __weak diag_rw_top_exit(void)
-{
-	//
-}
-
-int __weak diag_irq_trace_init(void)
-{
-	return 0;
-}
-
-void __weak diag_irq_trace_exit(void)
-{
-	//
-}
-
-int __weak diag_fs_shm_init(void)
-{
-	return 0;
-}
-
-void __weak diag_fs_shm_exit(void)
-{
-	//
-}
-
-int __weak diag_net_ping_delay_init(void)
-{
-	return 0;
-}
-
-void __weak diag_net_ping_delay_exit(void)
-{
-	//
-}
-
-int __weak diag_net_ping_delay6_init(void)
-{
-	return 0;
-}
-
-void __weak diag_net_ping_delay6_exit(void)
-{
-	//
-}
-
-int __weak diag_sys_broken_init(void)
-{
-	return 0;
-}
-
-void __weak diag_sys_broken_exit(void)
-{
-	//
-}
-
-int __weak diag_kprobe_init(void)
-{
-	return 0;
-}
-
-void __weak diag_kprobe_exit(void)
-{
-	//
-}
-
-int __weak diag_utilization_init(void)
-{
-	return 0;
-}
-
-void __weak diag_utilization_exit(void)
-{
-	//
-}
-
-int __weak diag_net_net_bandwidth_init(void)
-{
-	return 0;
-}
-
-void __weak diag_net_net_bandwidth_exit(void)
-{
-	//
-}
-
-int __weak diag_sig_info_init(void)
-{
-	return 0;
-}
-
-void __weak diag_sig_info_exit(void)
-{
-	//
-}
-
-int __weak exit_monitor_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak pupil_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak irq_delay_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak load_monitor_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak mutex_monitor_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak run_trace_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak rw_top_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak sys_delay_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
+#define DIAG_WEAK_FUNC_INIT_EXIT(name)                                \
+    int __weak diag_##name##_init(void) { return 0; }                 \
+    void __weak diag_##name##_exit(void) { return; }
+
+#define DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(name)                           \
+    int __weak activate_##name(void) { return -ENOTSUPP; }             \
+    int __weak deactivate_##name(void) { return -ENOTSUPP; }           \
+    long __weak diag_ioctl_##name(unsigned int cmd, unsigned long arg) \
+                { return -ENOTSUPP; }
+
+DIAG_WEAK_FUNC_INIT_EXIT(net)
+DIAG_WEAK_FUNC_INIT_EXIT(net_packet_corruption)
+DIAG_WEAK_FUNC_INIT_EXIT(net_redis_ixgbe)
+DIAG_WEAK_FUNC_INIT_EXIT(net_reqsk)
+
+DIAG_WEAK_FUNC_INIT_EXIT(vfs)
+DIAG_WEAK_FUNC_INIT_EXIT(fs)
+DIAG_WEAK_FUNC_INIT_EXIT(bio)
+DIAG_WEAK_FUNC_INIT_EXIT(blk_dev)
+DIAG_WEAK_FUNC_INIT_EXIT(nvme)
+
+DIAG_WEAK_FUNC_INIT_EXIT(rcu)
+DIAG_WEAK_FUNC_INIT_EXIT(lock)
+DIAG_WEAK_FUNC_INIT_EXIT(stack_trace)
+DIAG_WEAK_FUNC_INIT_EXIT(sys_loop)
+DIAG_WEAK_FUNC_INIT_EXIT(timer)
+DIAG_WEAK_FUNC_INIT_EXIT(kern_demo)
+DIAG_WEAK_FUNC_INIT_EXIT(sys_cost)
+DIAG_WEAK_FUNC_INIT_EXIT(task_time)
+DIAG_WEAK_FUNC_INIT_EXIT(task_runs)
+DIAG_WEAK_FUNC_INIT_EXIT(pupil)
+
+DIAG_WEAK_FUNC_INIT_EXIT(alloc_page)
+DIAG_WEAK_FUNC_INIT_EXIT(mm_page_fault)
+DIAG_WEAK_FUNC_INIT_EXIT(sys_broken)
+
+
+DIAG_WEAK_FUNC_INIT_EXIT(run_trace)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(run_trace)
+
+DIAG_WEAK_FUNC_INIT_EXIT(load)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(load_monitor)
+
+DIAG_WEAK_FUNC_INIT_EXIT(exit)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(exit_monitor)
+
+DIAG_WEAK_FUNC_INIT_EXIT(tcp_retrans)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(tcp_retrans)
 int __weak tcp_retrans_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
+DIAG_WEAK_FUNC_INIT_EXIT(sys_delay)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(sys_delay)
+
+DIAG_WEAK_FUNC_INIT_EXIT(irq_delay)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(irq_delay)
+
+DIAG_WEAK_FUNC_INIT_EXIT(mutex)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(mutex_monitor)
+
+DIAG_WEAK_FUNC_INIT_EXIT(utilization)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(utilization)
 int __weak utilization_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
+void __weak utilization_timer(struct diag_percpu_context *context)
+{
+    //
+}
 
-int __weak alloc_top_syscall(struct pt_regs *regs, long id)
+DIAG_WEAK_FUNC_INIT_EXIT(irq_stats)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(irq_stats)
+
+DIAG_WEAK_FUNC_INIT_EXIT(irq_trace)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(irq_trace)
+
+DIAG_WEAK_FUNC_INIT_EXIT(runq_info)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(runq_info)
+
+DIAG_WEAK_FUNC_INIT_EXIT(exec)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(exec_monitor)
+
+DIAG_WEAK_FUNC_INIT_EXIT(kprobe)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(kprobe)
+
+DIAG_WEAK_FUNC_INIT_EXIT(memory_leak)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(mm_leak)
+
+DIAG_WEAK_FUNC_INIT_EXIT(alloc_top)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(alloc_top)
+
+DIAG_WEAK_FUNC_INIT_EXIT(rw_top)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(rw_top)
+int __weak rw_top_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak drop_packet_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak exec_monitor_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(fs_shm)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(fs_shm)
 int __weak fs_shm_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak irq_stats_syscall(struct pt_regs *regs, long id)
+DIAG_WEAK_FUNC_INIT_EXIT(net_drop_packet)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(drop_packet)
+int __weak drop_packet_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak irq_trace_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
 
-int __weak kprobe_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak mm_leak_syscall(struct pt_regs *regs, long id)
-{
-	return -ENOSYS;
-}
-
-int __weak net_bandwidth_syscall(struct pt_regs *regs, long id)
-{
-        return -ENOSYS;
-}
-
-int __weak sig_info_syscall(struct pt_regs *regs, long id)
-{
-        return -ENOSYS;
-}
-
-int __weak activate_run_trace(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_run_trace(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_load_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_load_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_perf(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_exit_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_exit_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_perf(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_tcp_retrans(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_tcp_retrans(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_sys_delay(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_sys_delay(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_irq_delay(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_irq_delay(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_mutex_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_mutex_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_utilization(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_utilization(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_irq_stats(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_irq_stats(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_irq_trace(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_irq_trace(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_runq_info(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_runq_info(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_exec_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_exec_monitor(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_kprobe(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_kprobe(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_mm_leak(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_mm_leak(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_alloc_top(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_alloc_top(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_rw_top(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_rw_top(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_fs_shm(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_fs_shm(void)
-{
-	return -EINVAL;
-}
-
-int __weak activate_drop_packet(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_drop_packet(void)
-{
-	return -EINVAL;
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(sched_delay)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(sched_delay)
 int __weak sched_delay_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak activate_sched_delay(void)
-{
-	return -EINVAL;
-}
+DIAG_WEAK_FUNC_INIT_EXIT(reboot)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(reboot)
 
-int __weak deactivate_sched_delay(void)
-{
-	return -EINVAL;
-}
+DIAG_WEAK_FUNC_INIT_EXIT(xby_test)
 
-int __weak activate_reboot(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_reboot(void)
-{
-	return -EINVAL;
-}
-
-int __weak diag_xby_test_init(void)
-{
-	return 0;
-}
-
-void __weak diag_xby_test_exit(void)
-{
-	//
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(fs_orphan)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(fs_orphan)
 int __weak fs_orphan_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak activate_fs_orphan(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_fs_orphan(void)
-{
-	return -EINVAL;
-}
-
-int __weak diag_fs_orphan_init(void)
-{
-	return 0;
-}
-
-void __weak diag_fs_orphan_exit(void)
-{
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(net_ping_delay)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(ping_delay)
 int __weak ping_delay_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak activate_ping_delay(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_ping_delay(void)
-{
-	return -EINVAL;
-}
-
-int __weak diag_ping_delay_init(void)
-{
-	return 0;
-}
-
-void __weak diag_ping_delay_exit(void)
-{
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(net_ping_delay6)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(ping_delay6)
 int __weak ping_delay6_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak activate_ping_delay6(void)
-{
-	return -EINVAL;
-}
+DIAG_WEAK_FUNC_INIT_EXIT(ping_uprobe)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(ping_uprobe)
 
-int __weak deactivate_ping_delay6(void)
-{
-	return -EINVAL;
-}
-
-int __weak diag_ping_delay6_init(void)
-{
-	return 0;
-}
-
-void __weak diag_ping_delay6_exit(void)
-{
-}
-
-int __weak activate_uprobe(void)
-{
-	return -EINVAL;
-}
-
-int __weak deactivate_uprobe(void)
-{
-	return -EINVAL;
-}
-
-int __weak diag_uprobe_init(void)
-{
-	return 0;
-}
-
-void __weak diag_uprobe_exit(void)
-{
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(fs_cache)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(fs_cache)
 int __weak fs_cache_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak activate_fs_cache(void)
-{
-	return -EINVAL;
-}
 
-int __weak deactivate_fs_cache(void)
-{
-	return -EINVAL;
-}
-
-int __weak diag_fs_cache_init(void)
-{
-	return 0;
-}
-
-void __weak diag_fs_cache_exit(void)
-{
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(high_order)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(high_order)
 int __weak high_order_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak activate_high_order(void)
-{
-	return -EINVAL;
-}
+DIAG_WEAK_FUNC_INIT_EXIT(sig_info)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(sig_info)
 
-int __weak deactivate_high_order(void)
-{
-	return -EINVAL;
-}
-
-int __weak diag_high_order_init(void)
-{
-	return 0;
-}
-
-void __weak diag_high_order_exit(void)
-{
-}
-
-long __weak diag_ioctl_sys_delay(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_sys_cost(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_sched_delay(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_irq_delay(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_irq_stats(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_irq_trace(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_load_monitor(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_run_trace(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_perf(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_kprobe(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_uprobe(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_utilization(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_exit_monitor(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_mutex_monitor(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_exec_monitor(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_alloc_top(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_high_order(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_drop_packet(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_tcp_retrans(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_ping_delay(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_ping_delay6(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_rw_top(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_fs_shm(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_fs_orphan(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_fs_cache(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_reboot(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_net_bandwidth(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-long __weak diag_ioctl_sig_info(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(kern_perf)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(perf)
 int __weak perf_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
-
-int __weak deactivate_net_bandwidth(void)
+void __weak perf_timer(struct diag_percpu_context *context)
 {
-	return -EINVAL;
+    //
 }
 
-int __weak activate_net_bandwidth(void)
-{
-	return -EINVAL;
-}
-
-
-int __weak diag_task_monitor_init(void)
-{
-	return 0;
-}
-
-void __weak diag_task_monitor_exit(void)
-{
-	//
-}
-
-long __weak diag_ioctl_task_monitor(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
-int __weak task_monitor_syscall(struct pt_regs *regs, long id)
+DIAG_WEAK_FUNC_INIT_EXIT(net_bandwidth)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(net_bandwidth)
+int __weak net_bandwidth_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak deactivate_task_monitor(void)
+DIAG_WEAK_FUNC_INIT_EXIT(task_monitor)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(task_monitor)
+int __weak task_monitor_syscall(struct pt_regs *regs, long id)
 {
-	return -EINVAL;
+	return -ENOSYS;
 }
-
-int __weak activate_task_monitor(void)
-{
-	return -EINVAL;
-}
-
 void __weak task_monitor_timer(struct diag_percpu_context *context)
 {
         return;
 }
 
-long __weak diag_ioctl_throttle_delay(unsigned int cmd, unsigned long arg)
-{
-    return -EINVAL;
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(throttle_delay)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(throttle_delay)
 int __weak throttle_delay_syscall(struct pt_regs *regs, long id)
 {
     return -EINVAL;
 }
 
-int __weak deactivate_throttle_delay(void)
-{
-    return -EINVAL;
-}
-
-int __weak activate_throttle_delay(void)
-{
-    return -EINVAL;
-}
-
-int __weak diag_rw_sem_init(void)
-{
-        return 0;
-}
-
-void __weak diag_rw_sem_exit(void)
-{
-}
-
-long __weak diag_ioctl_rw_sem(unsigned int cmd, unsigned long arg)
-{
-        return -EINVAL;
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(rw_sem)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(rw_sem)
 int __weak rw_sem_syscall(struct pt_regs *regs, long id)
 {
         return -ENOSYS;
 }
 
-int __weak deactivate_rw_sem(void)
-{
-        return -EINVAL;
-}
-
-int __weak activate_rw_sem(void)
-{
-        return -EINVAL;
-}
-
-int __weak diag_rss_monitor_init(void)
-{
-	return 0;
-}
-
-void __weak diag_rss_monitor_exit(void)
-{
-	//
-}
-
-long __weak diag_ioctl_rss_monitor(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(rss_monitor)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(rss_monitor)
 int __weak rss_monitor_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak diag_memcg_stats_init(void)
-{
-	return 0;
-}
-
-void __weak diag_memcg_stats_exit(void)
-{
-}
-
-long __weak diag_ioctl_memcg_stats(unsigned int cmd, unsigned long arg)
-{
-	return -EINVAL;
-}
-
+DIAG_WEAK_FUNC_INIT_EXIT(memcg_stats)
+DIAG_WEAK_FUNC_ACT_DEACT_IOCTL(memcg_stats)
 int __weak memcg_stats_syscall(struct pt_regs *regs, long id)
 {
 	return -ENOSYS;
 }
 
-int __weak activate_memcg_stats(void)
+void __weak sys_loop_timer(struct diag_percpu_context *context)
 {
-    return -EINVAL;
+    //
 }
 
-int __weak deactivate_memcg_stats(void)
-{
-    return -EINVAL;
-}

--- a/deps/libunwind/src/dwarf/Gfind_proc_info-lsb.c
+++ b/deps/libunwind/src/dwarf/Gfind_proc_info-lsb.c
@@ -127,6 +127,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
       return 1;
     }
 
+#if defined(SHF_COMPRESSED)
   if (shdr->sh_flags & SHF_COMPRESSED)
     {
       unsigned long destSize;
@@ -161,6 +162,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
     }
   else
     {
+#endif
       *bufsize = shdr->sh_size;
       GET_MEMORY(*buf, *bufsize);
 
@@ -168,7 +170,9 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
 
       Debug (4, "read %zd bytes of .debug_frame from offset %zd\n",
 	     *bufsize, shdr->sh_offset);
+#if defined(SHF_COMPRESSED)
     }
+#endif
   munmap(ei.image, ei.size);
   return 0;
 }


### PR DESCRIPTION
(cherry picked from commit d9b061db93d777650d7d16b5ce687639a84a22c0)

A recent change broke builds for many non-recent and non-Linux targets
by adding code dependent on a non-portable preprocessor macro
SHF_COMPRESSED found in some more recent GLIBC elf.h headers.

This fixes the firt part of #190.

Signed-off-by: Stephen Webb <swebb@blackberry.com>
Signed-off-by: Wen Yang <simon.wy@alibaba-inc.com>