### PR TITLE
diagnose: avoid page faults when backtracking the stack

### DIFF
--- a/SOURCE/module/pub/stack.c
+++ b/SOURCE/module/pub/stack.c
@@ -142,7 +142,9 @@ copy_stack_frame(const void __user *fp, struct stackframe *frame)
 #endif
 		goto out;
 
+	pagefault_disable();
 	ret = __copy_from_user_inatomic(data, fp, 16);
+	pagefault_enable();
 	if (ret)
 		ret = -EFAULT;
 	else
@@ -832,8 +834,10 @@ void diag_task_raw_stack(struct task_struct *tsk, struct diag_raw_stack_detail *
 	stack = (char *)&detail->stack[0];
 	for (i = 0; i < (DIAG_USER_STACK_SIZE / 1024); i++) {
 		if (tsk == current) {
+			pagefault_disable();
 			ret = __copy_from_user_inatomic(stack,
 				(void __user *)sp + detail->stack_size, 1024);
+			pagefault_enable();
 		} else {
 			ret = diagnose_task_raw_stack_remote(tsk, stack,
 				(void __user *)sp + detail->stack_size, 1024);


### PR DESCRIPTION
Fixed this issue:
[23914088.479164] Call Trace:
[23914088.482211]  ? should_numa_migrate_memory+0x54/0x170
[23914088.487777]  ? mpol_misplaced+0x135/0x1a0
[23914088.492376]  do_numa_page+0x29e/0x2b4
[23914088.496629]  handle_mm_fault+0x970/0xda0
[23914088.501146]  ? futex_wait_queue_me+0xc1/0x120
[23914088.506106]  ? futex_wait+0xf6/0x250
[23914088.510279]  ? do_futex+0xb8/0x600
[23914088.514272]  __do_page_fault+0x26b/0x4a 0
[23914088.518785]  do_page_fault+0x32/0x110
[23914088.523033]  page_fault+0x1e/0x30
[23914088.526933] RIP: 0010:copy_user_enhanced_fast_string+0xe/0x20
[23914088.533264] Code: 89 d1 c1 e9 03 83 e2 07 f3 48 a5 89 d1 f3 a4 31 c0 0f 01 ca c3 0f 1f 80 00 00 00 00 0f 01 cb 83 fa 40 0f 82 70 ff ff ff 89 d1 <f3> a4 31 c0 0f 01 ca c3 66 2e 0f 1f 84 00 00 00 00 00 89 d1 83 f8
[23914088.553153] RSP: 0018:ffffc900758afd50 EFLAGS: 00050006
[23914088.558968] RAX: 0000000000000000 RBX: ffffffffc1930070 RCX: 00000000000000a0
[23914088.566933] RDX: 0000000000000400 RSI: 00007fedf6400000 RDI: ffffffffc19303d0
[23914088.574896] RBP: ffffffffc192e7a8 R08: ffffffffc192e7a0 R09: ffffffffc192e870
[23914088.582859] R10: 0000000000000000 R11: 0000000000000040 R12: ffff88a308b92f80
[23914088.590824] R13: ffff88a308b92f80 R14: ffffffffc1932870 R15: 00007fedf63fe4a0
[23914088.598813]  diag_task_raw_stack+0xfd/0x170 [diagnose]
[23914088.604547]  ? kernfs_name+0x42/0x50
[23914088.608734]  stop_run_trace+0x2c1/0x330 [diagnose]
[23914088.614125]  ? kernfs_name+0x42/0x50
[23914088.618310]  trace_sys_exit_hit+0x74/0x1b0 [diagnose]
[23914088.623966]  syscall_slow_exit_work+0x96/0xc0
[23914088.628924]  do_syscall_64+0x137/0x200
[23914088.633267]  entry_SYSCALL_64_after_hwframe+0x44/0xa9